### PR TITLE
Rename project and add wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# resp
+# restrained_ESP_fit
 
 This is a fork of the `resp` program commonly used in computational chemistry for fitting partial charges to values of the provided molecular Electrostatic Potential (ESP) field around a molecule.
 The method was first described by Bayly et al.¹ using the MK mesh of sampling the ESP field² but the program can generally fit charges to any mesh of points.
@@ -8,6 +8,7 @@ History prior to version 2.2 was not preserved (or rather, reconstructed, consid
 This version was downloaded in May 2020 from https://upjv.q4md-forcefieldtools.org/RED/ together with other programs in q4md-fft tools 2.0.
 The original README for this version can be found in the [`README-2.4.txt` file](https://github.com/jszopi/resp/blob/master/README-2.4.txt) — see for build instructions.
 Usage instructions are only available for version 2.2 and are hosted at https://upjv.q4md-forcefieldtools.org/RED/resp/ (if link is down, get your browser to display [the repo version](https://github.com/jszopi/resp/blob/566c9207b87ed37c6a8b2e47a581704db762f16c/resp-2.2.html)).
+Use the `restrained_ESP_fit` script to invoke the program, as the name `resp` is now deprecated. 
 
 I am hoping to rewrite this program in Python in order to encourage users to experiment with their own fitting methods.
 The code will thus soon be available in PyPI, possibly under a less generic name.

--- a/restrained_ESP_fit
+++ b/restrained_ESP_fit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./resp "$@"


### PR DESCRIPTION
`resp` was taken in PyPI and was too generic anyway. Renamed to `restrained_ESP_fit`.