### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
 compiler:
-    - gcc
+    - gfortran
 script:
   - make
-  - ./restricted_ESP_fit
+  - restricted_ESP_fit

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
     - os: osx
       osx_image: xcode10.1
 language: c
-before_install:
-  - sudo apt-get install gfortran
+compiler:
+    - gcc
 script:
   - make
   - ./restricted_ESP_fit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ matrix:
       dist: xenial
     - os: osx
       osx_image: xcode10.1
-compiler:
-    - gcc
 script:
   - make
-  - restricted_ESP_fit
+addons:
+    apt:
+        packages: gfortran
+    homebrew:
+        packages: gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ matrix:
       dist: xenial
     - os: osx
       osx_image: xcode10.1
-language:
-    - fortran
+compiler:
+    - gcc
 script:
   - make
   - restricted_ESP_fit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
       dist: xenial
     - os: osx
       osx_image: xcode10.1
-language: c
 compiler:
     - gcc
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       osx_image: xcode10.1
 script:
   - make
-  - bash restricted_ESP_fit
+  - ./restrained_ESP_fit
 addons:
     apt:
         packages: gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
-sudo: false
+sudo: required
 matrix:
   include:
     - os: linux
       dist: xenial
-      language: generic
     - os: osx
       osx_image: xcode10.1
-      language: generic
+language: c
+before_install:
+  - sudo apt-get install gfortran
 script:
-  make
+  - make
+  - ./restricted_ESP_fit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+      language: generic
+    - os: osx
+      osx_image: xcode10.1
+      language: generic
+script:
+  make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
       osx_image: xcode10.1
 script:
   - make
+  - bash restricted_ESP_fit
 addons:
     apt:
         packages: gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ matrix:
       dist: xenial
     - os: osx
       osx_image: xcode10.1
-compiler:
-    - gfortran
+language:
+    - fortran
 script:
   - make
   - restricted_ESP_fit

--- a/restrained_ESP_fit
+++ b/restrained_ESP_fit
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./resp "$@"
+"$(dirname $0)"/resp "$@"


### PR DESCRIPTION
For both Linux and MacOS. Includes calling the `restrained_ESP_fit` script instead of invoking `resp`.