### PR TITLE
Add setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+build/
+dist/
+restrained_ESP_fit.egg-info
+restrained_ESP_fit/resp
+restrained_ESP_fit/resp.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ matrix:
 script:
   - pip3 install -e .
   - restrained_ESP_fit
+deploy:
+    provider: pypi
+    username: __token__
+    password: $TEST_PYPI_TOKEN
+    server: https://test.pypi.org/legacy/
 addons:
     apt:
         packages: gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,7 @@ matrix:
         - TRAVIS_PYTHON_VERSION="3.7"
 script:
   - pip3 install -e .
-  - restrained_ESP_fit
-deploy:
-    provider: pypi
-    username: __token__
-    password: $TEST_PYPI_TOKEN
-    server: https://test.pypi.org/legacy/
+  - restrained_ESP_fit  # The target `resp` binary always returns 0
 addons:
     apt:
         packages: gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       env:
         - TRAVIS_PYTHON_VERSION="3.7"
 script:
-  - pip install -e .
+  - pip3 install -e .
   - restrained_ESP_fit
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
 language: python
-python: "3.7"
+python: "3.8"
 script:
   - pip install -e .
   - restrained_ESP_fit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     - os: linux
       dist: xenial
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode11.5
 language: python
 python: "3.8"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ matrix:
   include:
     - os: linux
       dist: xenial
+      language: python
+      python: "3.7"
     - os: osx
       osx_image: xcode11.5
-language: python
-python: "3.8"
+      language: generic
+      env:
+        - TRAVIS_PYTHON_VERSION="3.7"
 script:
   - pip install -e .
   - restrained_ESP_fit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ matrix:
       dist: xenial
     - os: osx
       osx_image: xcode10.1
+language: python
+python: "3.7"
 script:
-  - make
-  - ./restrained_ESP_fit
+  - pip install -e .
+  - restrained_ESP_fit
 addons:
     apt:
         packages: gfortran

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,3 @@
-Copyright 2016 Jan Szopinski (Hunt Research Group, Imperial College London)
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/restrained_ESP_fit
+++ b/restrained_ESP_fit
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-"$(dirname $0)"/resp "$@"

--- a/restrained_ESP_fit/resp_wrapper.py
+++ b/restrained_ESP_fit/resp_wrapper.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import datetime
+import pkg_resources
+import sys
+import subprocess
+
+def main():
+    resp_binary = pkg_resources.resource_filename(__name__, "resp")
+    with open(f"temp+{datetime.datetime.now()}", 'w') as fh:
+        fh.write(f"\n{resp_binary}")
+    subprocess.run([resp_binary, *sys.argv[1:]]).check_returncode()

--- a/restrained_ESP_fit/resp_wrapper.py
+++ b/restrained_ESP_fit/resp_wrapper.py
@@ -7,6 +7,4 @@ import subprocess
 
 def main():
     resp_binary = pkg_resources.resource_filename(__name__, "resp")
-    with open(f"temp+{datetime.datetime.now()}", 'w') as fh:
-        fh.write(f"\n{resp_binary}")
     subprocess.run([resp_binary, *sys.argv[1:]]).check_returncode()

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ config = {
     'description': 'Fitting partial charges to molecular Electrostatic Potential field',
     'long_description': long_description,
     'long_description_content_type': 'text/markdown',
-    'author': 'Jan Szopinski',
-    'author_email': 'jszopi@users.noreply.github.com',
+    'maintainer': 'Jan Szopinski',
+    'maintainer_email': 'jszopi@users.noreply.github.com',
     'url': 'https://github.com/jszopi/restrained_ESP_fit',
     'license': 'GPLv3',
     # Probably not the best way of making the `resp` binary accessible:

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ except ImportError:
 
 import subprocess
 
-subprocess.run("make").check_returncode()
-subprocess.run("./restrained_ESP_fit").check_returncode()  # Always returns 0
+subprocess.run(["make"]).check_returncode()
+subprocess.run(["./restrained_ESP_fit"]).check_returncode()  # Always returns 0
 
 config = {
     'name': 'restrained_ESP_fit',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ config = {
     'url': 'https://github.com/jszopi/restrained_ESP_fit',
     'packages': [],
     'license': 'GPLv3',
-    'scripts': ["restrained_ESP_fit"],
+    'scripts': ["resp", "restrained_ESP_fit"],
 }
 
 setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,28 @@
 from setuptools import setup
 import subprocess
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 subprocess.run(["make"]).check_returncode()
-subprocess.run(["./restrained_ESP_fit"]).check_returncode()  # Always returns 0
+subprocess.run(["mv", "resp.o", "resp", "restrained_ESP_fit"]).check_returncode()  # Always returns 0
 
 config = {
     'name': 'restrained_ESP_fit',
     'version': '2.4.1',
     'description': 'Fitting partial charges to molecular Electrostatic Potential field',
+    'long_description': long_description,
+    'long_description_content_type': 'text/markdown',
     'author': 'Jan Szopinski',
     'author_email': 'jszopi@users.noreply.github.com',
     'url': 'https://github.com/jszopi/restrained_ESP_fit',
-    'packages': [],
     'license': 'GPLv3',
-    'scripts': ["restrained_ESP_fit"],
+    # Probably not the best way of making the `resp` binary accessible:
+    'packages': ["restrained_ESP_fit"],
+    'package_data': {"restrained_ESP_fit": ["resp"]},
+    'entry_points': {
+        'console_scripts': ["restrained_ESP_fit=restrained_ESP_fit.resp_wrapper:main"],
+    },
 }
 
 setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 import subprocess
 
 subprocess.run("make").check_returncode()
-subprocess.run("./restrained_ESP_fit").check_returncode()
+subprocess.run("./restrained_ESP_fit").check_returncode()  # Always returns 0
 
 config = {
     'name': 'restrained_ESP_fit',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,4 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
+from setuptools import setup
 import subprocess
 
 subprocess.run(["make"]).check_returncode()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ config = {
     'packages': [],
     'license': 'GPLv3',
     'entry_points': {
-        'console_scripts': "restrained_ESP_fit=restrained_ESP_fit:main"
+        'console_scripts': ["restrained_ESP_fit=restrained_ESP_fit:main"]
     },
 }
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ config = {
     'url': 'https://github.com/jszopi/restrained_ESP_fit',
     'packages': [],
     'license': 'GPLv3',
-    'scripts': ["resp", "restrained_ESP_fit"],
+    'scripts': [],
 }
 
 setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+import subprocess
+
+subprocess.run("make").check_returncode()
+subprocess.run("./restrained_ESP_fit").check_returncode()
+
+config = {
+    'name': 'restrained_ESP_fit',
+    'version': '2.4.1',
+    'description': 'Fitting partial charges to molecular Electrostatic Potential field',
+    'author': 'Jan Szopinski',
+    'author_email': 'jszopi@users.noreply.github.com',
+    'url': 'https://github.com/jszopi/restrained_ESP_fit',
+    'packages': [],
+    'license': 'GPLv3',
+    'entry_points': {
+        'console_scripts': "restrained_ESP_fit=restrained_ESP_fit:main"
+    },
+}
+
+setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ config = {
     'url': 'https://github.com/jszopi/restrained_ESP_fit',
     'packages': [],
     'license': 'GPLv3',
-    'scripts': [],
+    'scripts': ["restrained_ESP_fit"],
 }
 
 setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,7 @@ config = {
     'url': 'https://github.com/jszopi/restrained_ESP_fit',
     'packages': [],
     'license': 'GPLv3',
-    'entry_points': {
-        'console_scripts': ["restrained_ESP_fit=restrained_ESP_fit:main"]
-    },
+    'scripts': ["restrained_ESP_fit"],
 }
 
 setup(**config)


### PR DESCRIPTION
Compile the Fortran source during Python installation with setup.py and make it available through a Python script.