### PR TITLE
Use dashes instead of underscores in package and script names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
 
     - name: Run the `resp` binary in lieu of tests (returns 0)
       if: ${{ !startsWith(matrix.build, 'manylinux') }}
-      run: restrained_ESP_fit
+      run: restrained-ESP-fit
 
     - name: Uninstall restrained-ESP-fit
       if: ${{ !startsWith(matrix.build, 'manylinux') }}
@@ -143,11 +143,11 @@ jobs:
       run: pip install -v restrained-ESP-fit --no-index --only-binary restrained-ESP-fit -f dist/
 
     - name: Run the `resp` binary in lieu of tests (returns 0)
-      run: restrained_ESP_fit
+      run: restrained-ESP-fit
 
     - name: Verify that libraries are linked into `resp` as expected
       run: |
-        INSTALLED_MODULE="$(pip show restrained_ESP_fit | grep "^Location" | cut -f2 -d" ")"
+        INSTALLED_MODULE="$(pip show restrained-ESP-fit | grep "^Location" | cut -f2 -d" ")"
         RESP_BINARY="$INSTALLED_MODULE"/restrained_ESP_fit/build/resp
         LINK_DEPS_UTIL="${{ matrix.build == 'macos' && 'otool' || 'ldd' }}"
         ./.github/workflows/validate-link.py "$LINK_DEPS_UTIL" "$RESP_BINARY" ${{matrix.expected-dyn-libs}}

--- a/setup.py
+++ b/setup.py
@@ -29,20 +29,20 @@ class build_(distutils.command.build.build):
 
 
 config = {
-    'name': 'restrained_ESP_fit',
+    'name': 'restrained-ESP-fit',
     'description': 'Fitting partial charges to molecular Electrostatic Potential field',
     'long_description': long_description,
     'long_description_content_type': 'text/markdown',
     'maintainer': 'Jan Szopinski',
     'maintainer_email': 'jszopi@users.noreply.github.com',
-    'url': 'https://github.com/jszopi/restrained_ESP_fit',
+    'url': 'https://github.com/jszopi/restrained-ESP-fit',
     'license': 'GPLv3',
     'packages': ["restrained_ESP_fit"],
     'package_data': {"restrained_ESP_fit": ["build/resp"]},
     # Hacky? Causes the `resp` binary to be included in bdist_wheel but not in sdist
     'include_package_data': True,
     'entry_points': {
-        'console_scripts': ["restrained_ESP_fit=restrained_ESP_fit.resp_wrapper:main"],
+        'console_scripts': ["restrained-ESP-fit=restrained_ESP_fit.resp_wrapper:main"],
     },
     'cmdclass': {'build': build_},
     # Removing the local version as PyPI doesn't allow it


### PR DESCRIPTION
Use dashes instead of underscores in package and script names, but not in module name.